### PR TITLE
`undefined` value should delete object key

### DIFF
--- a/__tests__ /general/merging.test.js
+++ b/__tests__ /general/merging.test.js
@@ -178,6 +178,21 @@ describe("when merging two objects it", function () {
 
         expect(objects).toMatchSnapshot();
     });
+
+    test("should delete the object key for an undefined value", function () {
+
+        const object1 = {
+            "prop": 1
+        };
+
+        const object2 = {
+            "prop": undefined
+        };
+
+        const result = jsonMerger.mergeObjects([object1, object2], {stringify: false});
+
+        expect(result.hasOwnProperty("prop")).toBe(false);
+    });
 });
 
 describe("when merging two arrays it", function () {

--- a/__tests__ /operations/remove.test.js
+++ b/__tests__ /operations/remove.test.js
@@ -23,6 +23,23 @@ describe("when merging two objects and a source property has a $remove indicator
 
         expect(result).toMatchSnapshot();
     });
+
+    test("it should delete the object key for an undefined value", function () {
+
+        const object1 = {
+            "a": 1
+        };
+
+        const object2 = {
+            "a": {
+                "$remove": true
+            }
+        };
+
+        const result = jsonMerger.mergeObjects([object1, object2], {stringify: false});
+
+        expect(result.hasOwnProperty("a")).toBe(false);
+    });
 });
 
 describe("when merging two arrays and a source property has a $remove indicator", function () {

--- a/src/Processor.ts
+++ b/src/Processor.ts
@@ -301,6 +301,11 @@ export default class Processor {
             // process source property and copy to result
             const targetKey = this.isEscapedKeyword(key) ? this.stripOperationPrefix(key) : key;
             result[targetKey] = this.processSourceProperty(source[key], key, target[key]);
+
+            // value of "undefined" indicates the property must be deleted (see "remove" operation)
+            if (typeof result[targetKey] === "undefined") {
+                delete result[targetKey];
+            }
         });
 
         return result;


### PR DESCRIPTION
fix: `Processor` should delete object key when `processSourceProperty()` returns `undefined`