### PR TITLE
update vm2 to 3.9.17 and other fixes

### DIFF
--- a/__tests__/operations/expression.test.js
+++ b/__tests__/operations/expression.test.js
@@ -38,7 +38,7 @@ describe("when merging two objects and a source property has an $expression oper
         `An error occurred while processing the property "$expression"`
       );
       expect(e.message).toMatch(`at #/a/$expression`);
-      expect(e.message).toMatch(`Unexpected character '@'`);
+      expect(e.message).toMatch(`Invalid or unexpected token`);
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "json-ptr": "^3.1.0",
         "jsonpath": "^1.1.1",
         "lodash.range": "^3.2.0",
-        "vm2": "^3.9.9"
+        "vm2": "^3.9.17"
       },
       "bin": {
         "json-merger": "bin/json-merger.js"
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
-      "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -4982,9 +4982,9 @@
       }
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
     "@types/prettier": {
@@ -7184,9 +7184,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "underscore": {
@@ -7219,9 +7219,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
-      "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "json-ptr": "^3.1.0",
     "jsonpath": "^1.1.1",
     "lodash.range": "^3.2.0",
-    "vm2": "^3.9.9"
+    "vm2": "^3.9.17"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "skipLibCheck": true,
     "declaration": true,
     "module": "commonjs",
     "noImplicitAny": true,
@@ -11,6 +12,5 @@
     "sourceMap": true,
     "target": "ES5"
   },
-  "include": ["./src/index.ts"],
-  "exclude": ["node_modules"]
+  "include": ["./src/index.ts"]
 }


### PR DESCRIPTION
For security: https://github.com/patriksimek/vm2/releases/tag/3.9.17
SkipLibcheck will exclude  node modules when running tsc
Update test case that was failing on master (at least for me)